### PR TITLE
Create .coveralls.yml

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+repo_token: sShH6UsxQvRz85G6z4wuHe5KpEdC7CjXW


### PR DESCRIPTION
`Create .coveralls.yml`
Coveralls not picking up the coverage. Trying to include `.coveralls.yml`, see if this changes the behavior.